### PR TITLE
Fix invalid backend URLs being returned from getGameConfig when not using external IP finding

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -642,7 +642,7 @@ export class Mod implements IPreAkiLoadMod, IPostDBLoadMod
 
     public getGameConfig(sessionID: string): IGameConfigResponse
     {
-        let externalIp = `${this.coopConfig.externalIP}`;
+        let externalIp = `http://${this.coopConfig.externalIP}:6969`;
 
         if(this.coopConfig.useExternalIPFinder) { 
             console.log(`============================================================`);


### PR DESCRIPTION
As-is, the backend URLs returned from `getGameConfig` when *not* automatically finding an external IP do not match the URLs returned from the SPT implementation of the method, and seem to be invalid.
For example: setting externalIP to `10.10.10.10` will result in the backend URLs provided to the game being `10.10.10.10` and not `http://10.10.10.10:6969`. The end result of this is the game failing to load beyond "Loading profile data" and eventually exiting after a vague "Backend error".

Hardcoding the `http://` and `:6969` onto the externalIP (like is done with the result of external IP finding) appears to fix the problem for my friends and I. I also considered a few other ways to fix this but quickly realized that my typescript skills were *not* up to par to do anything fancy.