### PR TITLE
Refactored client ping calculation to use round-trip time

### DIFF
--- a/src/CoopMatch.ts
+++ b/src/CoopMatch.ts
@@ -144,6 +144,11 @@ export class CoopMatch {
             return;
         }
 
+        if(info.m === "Ping" && info.t !== undefined && info.accountId !== undefined) {
+            this.Ping(info.accountId, info.t);
+            return;
+        }
+
         if(info.m === "SpawnPointForCoop") {
 
             this.SpawnPoint.x = info.x;
@@ -158,12 +163,6 @@ export class CoopMatch {
 
             if(this.ConnectedPlayers.length == 0)
                 this.endSession(CoopMatchEndSessionMessages.HOST_SHUTDOWN_MESSAGE);
-
-            return;
-        }
-
-        if(info.t !== undefined && info.accountId !== undefined && info.m === "Ping") {
-            this.Ping(info.accountId, info.t);
 
             return;
         }

--- a/src/CoopMatch.ts
+++ b/src/CoopMatch.ts
@@ -104,7 +104,7 @@ export class CoopMatch {
         this.SendPingInterval = setInterval(() => {
 
             var dateOfPing = new Date(Date.now());
-            var dateOfPingString = `${dateOfPing.getHours()}:${dateOfPing.getMinutes()}:${dateOfPing.getSeconds()}:${dateOfPing.getMilliseconds()}`;
+            var dateOfPingString = dateOfPing.toISOString();
             // console.log(dateOfPingString);
             WebSocketHandler.Instance.sendToWebSockets(this.ConnectedPlayers, JSON.stringify({ ping: dateOfPingString }));
 


### PR DESCRIPTION
This gets rid of the server calculated timestamps and allows the client to calculate their own round-trip time, requires SIT.Core on EFT client to contain these changes https://github.com/paulov-t/SIT.Core/pull/333