### PR TITLE
add arbitrary size limit to PreviousSentData

### DIFF
--- a/src/CoopMatch.ts
+++ b/src/CoopMatch.ts
@@ -69,7 +69,7 @@ export class CoopMatch {
     // DamageArray: any[] = [];
 
     PreviousSentData: string[] = [];
-
+	PreviousSentDataMaxSize: int = 128;
 
     Status: CoopMatchStatus = CoopMatchStatus.Loading;
     Settings: any = {};
@@ -229,9 +229,13 @@ export class CoopMatch {
         this.LastUpdateDateTime = new Date(Date.now());
 
         const serializedData = JSON.stringify(info);
-        if (this.PreviousSentData.findIndex(x => x == serializedData) !== -1)
-            return;
-
+        
+		if (this.PreviousSentData.findIndex(x => x == serializedData) !== -1)
+			return;
+			
+		if(this.PreviousSentData.length >= this.PreviousSentDataMaxSize)
+			this.PreviousSentData = [];
+		
         this.PreviousSentData.push(serializedData);
 
         WebSocketHandler.Instance.sendToWebSockets(this.ConnectedUsers, serializedData);


### PR DESCRIPTION
The current implementation for checking duplicate data is realistically unsustainable because eventually the PreviousSentData variable will become so big that iterating through it will cause enormous lags and eventually leading to server unresponsiveness.

This PR simply adds an arbitrary size check and clears the PreviousSentData when reached. However, I am not certain that the size is enough to cover potential duplicate data, so obviously this is up for discussion. I believe we should keep the PreviousSentData size as low as possible to ensure proper server performance.