### PR TITLE
Add timestamp to CoopMatch

### DIFF
--- a/src/StayInTarkovMod.ts
+++ b/src/StayInTarkovMod.ts
@@ -284,6 +284,7 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
                         }
 
                         CoopMatch.CoopMatches[info.serverId] = new CoopMatch(info);
+                        CoopMatch.CoopMatches[info.serverId].Timestamp = info.timestamp;
                         CoopMatch.CoopMatches[info.serverId].Location = info.settings.location;
                         CoopMatch.CoopMatches[info.serverId].Time = info.settings.timeVariant;
                         CoopMatch.CoopMatches[info.serverId].WeatherSettings = info.settings.timeAndWeatherSettings;
@@ -347,6 +348,7 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
                         output = JSON.stringify(coopMatch !== null ? 
                             { 
                                 ServerId: coopMatch.ServerId
+                                , timestamp: coopMatch.Timestamp
                                 , expectedNumberOfPlayers: coopMatch.ExpectedNumberOfPlayers 
                                 , sitVersion: coopMatch.SITVersion 
                                 , gameVersion: coopMatch.GameVersion


### PR DESCRIPTION
Save timestamp to CoopMatch when host create a raid, needed for my "new feature" and maybe we can use it somewhere else in future.