### PR TITLE
better implementation for server-side authorization check

### DIFF
--- a/src/CoopMatch.ts
+++ b/src/CoopMatch.ts
@@ -56,6 +56,8 @@ export class CoopMatch {
     /** The Connected User Profiles. */
     public ConnectedUsers: string[] = [];
 
+    public AuthorizedUsers: string[] = [];
+
     /** All characters in the game. Including AI */
     public Characters: any[] = [];
 
@@ -251,16 +253,28 @@ export class CoopMatch {
     }
 
     public PlayerJoined(profileId: string) {
+        
+        if(profileId.startsWith("pmc") && this.ConnectedUsers.findIndex(x => x == profileId) === -1) {
+
+            console.log(`Checking server authorization for profile: ${profileId}`);
+
+            if(this.AuthorizedUsers.findIndex(x => x == profileId) === -1)
+            {
+                console.log(`${profileId} is not authorized in server: ${this.ServerId}`);
+    
+                WebSocketHandler.Instance.closeWebSocketSession(profileId, CoopMatchEndSessionMessages.WEBSOCKET_TIMEOUT_MESSAGE);
+    
+                return;
+            }
+
+            this.ConnectedUsers.push(profileId);
+            console.log(`${this.ServerId}: ${profileId} has joined`);
+        }
+        
         if(this.ConnectedPlayers.findIndex(x => x == profileId) === -1) {
             this.ConnectedPlayers.push(profileId);
             // console.log(`${this.ServerId}: ${profileId} has joined`);
         }
-
-        if(profileId.startsWith("pmc") && this.ConnectedUsers.findIndex(x => x == profileId) === -1) {
-            this.ConnectedUsers.push(profileId);
-            console.log(`${this.ServerId}: ${profileId} has joined`);
-        }
-
     }
 
     public PlayerLeft(profileId: string) {

--- a/src/StayInTarkovMod.ts
+++ b/src/StayInTarkovMod.ts
@@ -291,6 +291,7 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
                         CoopMatch.CoopMatches[info.serverId].GameVersion = info.gameVersion;
                         CoopMatch.CoopMatches[info.serverId].SITVersion = info.sitVersion;
                         CoopMatch.CoopMatches[info.serverId].Password = info.password !== undefined ? info.password : undefined;
+                        CoopMatch.CoopMatches[info.serverId].AuthorizedUsers.push(info.serverId);
                         output = JSON.stringify({ serverId:  info.serverId });
                         return output;
                     }
@@ -367,7 +368,6 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
                             return output;
                         }
 
-
                         if (coopMatch.Password !== "") {
                             if(info.password == "")
                             {
@@ -388,8 +388,13 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
                                 )
                                 return output;
                             }
-                        } 
-
+                        }
+                        
+                        if(coopMatch.AuthorizedUsers.findIndex(x => x == info.profileId) === -1)
+                        {
+                            coopMatch.AuthorizedUsers.push(info.profileId);
+                            logger.info(`Added authorized user: ${info.profileId} in server: ${coopMatch.ServerId}`);
+                        }
 
                         output = JSON.stringify(coopMatch !== null ? 
                             { 


### PR DESCRIPTION
Same end result as previous commit however this is more secure because you can only get authorized to join the server if you have a successful JoinMatch handshake. The authorized users are now tied to the CoopMatch, fixing a security flaw in the previous commit.